### PR TITLE
Remove Default Hardcoded auth token

### DIFF
--- a/baremetal_network_provisioning/ml2/hp_network_provisioning_driver.py
+++ b/baremetal_network_provisioning/ml2/hp_network_provisioning_driver.py
@@ -34,7 +34,7 @@ hp_opts = [
     cfg.StrOpt('base_url',
                help=_("Base HTTP URL of  SDN controller")),
     cfg.StrOpt('auth_token',
-               default='AuroraSdnToken37',
+               default='password',
                help=_("Authentication token for SDN controller")),
     cfg.StrOpt('ca_cert',
                default=None,


### PR DESCRIPTION
This change is to address the need to eliminate the default hard coded authentation token of Flare Controller.