### PR TITLE
Enabled the neutron-bnp script in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,8 @@ data_files =
         etc/hp_network_provisioning_conf.ini
 
 [entry_points]
+console_scripts =
+    neutron-bnp = baremetal_network_provisioning.bnpclient.bnp_client_ext.shell:main
 neutron.db.alembic_migrations =
     baremetal-network-provisioning = baremetal_network_provisioning.db.migration:alembic_migrations
 neutron.ml2.extension_drivers =


### PR DESCRIPTION
This change is to enable the neutron-bnp script as part of setup.cfg so that the executable will be automatically copied to /usr/local/bin