### PR TITLE
Fix for Defect #189911: For ports which are multiples of 8 Neutron port creation fails

### DIFF
--- a/baremetal_network_provisioning/common/snmp_client.py
+++ b/baremetal_network_provisioning/common/snmp_client.py
@@ -169,8 +169,10 @@ class SNMPClient(object):
 
     def get_bit_map_for_add(self, val, egress_byte):
         ifindex = val
-        byte_index = int(ifindex) / 8
+        byte_index = int(ifindex - 1) / 8
         bit_index = int(ifindex) % 8
+        if bit_index == 0:
+            bit_index = 8
         target_byte = egress_byte[byte_index]
         mask = 0x80
         if bit_index >= 1:
@@ -187,8 +189,10 @@ class SNMPClient(object):
 
     def get_bit_map_for_del(self, val, egress_byte):
         ifindex = val
-        byte_index = int(ifindex) / 8
+        byte_index = int(ifindex - 1) / 8
         bitindex = int(ifindex) % 8
+        if bitindex == 0:
+            bitindex = 8
         target_byte = egress_byte[byte_index]
         mask = 0x80
         if bitindex > 1:


### PR DESCRIPTION
Fix for Defect #189911: For ports which are multiples of 8 Neutron port creation fails

Issue:
1. If target ifindex is multiple of 8, it is overflowing to following byte rather than indexing right byte.
2. bit index is calculated by generating modulus of ifdex with 8. so, ifindex is multiple of 8, bit_index is pointing to first bit rather than last bit in target byte.

Fix:
decremented ifdex by 1, then diving with 8 to get right byte index.
if bit index is 0, then assigning 8 to bit_index such that it points last bit of target byte.
    