### PR TITLE
Fix for Defect # 178828:"After Neutron Port delete, Vlan on port is deleted but Global vlan still exists on switch"

### DIFF
--- a/baremetal_network_provisioning/drivers/snmp_driver.py
+++ b/baremetal_network_provisioning/drivers/snmp_driver.py
@@ -77,9 +77,7 @@ class SNMPDriver(driver.PortProvisioningDriver):
                 bit_list.append(line)
             set_string = client.get_rfc1902_octet_string(''.join(bit_list))
             client.set(egress_oid, set_string)
-            is_last_port_vlan = port['port']['is_last_port_vlan']
-            if is_last_port_vlan:
-                client.set(vlan_oid, client.get_rfc1902_integer(6))
+            # On port delete removing interface from target vlan, not deleting global vlan on device
         except Exception as e:
             LOG.error(_LE("Exception in deleting VLAN '%s' "), e)
             raise exceptions.SNMPFailure(operation="SET", error=e)

--- a/baremetal_network_provisioning/drivers/snmp_driver.py
+++ b/baremetal_network_provisioning/drivers/snmp_driver.py
@@ -67,7 +67,6 @@ class SNMPDriver(driver.PortProvisioningDriver):
         try:
             client = snmp_client.get_client(self._get_switch_dict(port))
             seg_id = port['port']['segmentation_id']
-            vlan_oid = constants.OID_VLAN_CREATE + '.' + str(seg_id)
             egress_oid = constants.OID_VLAN_EGRESS_PORT + '.' + str(seg_id)
             nibble_byte = self._get_device_nibble_map(client, egress_oid)
             ifindex = port['port']['ifindex']

--- a/baremetal_network_provisioning/drivers/snmp_driver.py
+++ b/baremetal_network_provisioning/drivers/snmp_driver.py
@@ -77,7 +77,8 @@ class SNMPDriver(driver.PortProvisioningDriver):
                 bit_list.append(line)
             set_string = client.get_rfc1902_octet_string(''.join(bit_list))
             client.set(egress_oid, set_string)
-            # On port delete removing interface from target vlan, not deleting global vlan on device
+            # On port delete removing interface from target vlan,
+            #  not deleting global vlan on device
         except Exception as e:
             LOG.error(_LE("Exception in deleting VLAN '%s' "), e)
             raise exceptions.SNMPFailure(operation="SET", error=e)


### PR DESCRIPTION
Fix:
On neutron port delete removing interface from target vlan, but not deleting global vlan on device.