### PR TITLE
Addressed Review comments for Credential Create REST API's

### DIFF
--- a/baremetal_network_provisioning/common/constants.py
+++ b/baremetal_network_provisioning/common/constants.py
@@ -1,5 +1,5 @@
 # Copyright 2015 OpenStack Foundation
-# Copyright (c) 2015 Hewlett-Packard Development Company, L.P.
+# Copyright (c) 2016 Hewlett-Packard Development Company, L.P.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -15,7 +15,9 @@
 # service type constants:
 
 BNP_SWITCH_RESOURCE_NAME = 'bnp_switch'
+BNP_CREDENTIAL_RESOURCE_NAME = 'bnp_credential'
 
+NAME = 'name'
 TRUNK = 'trunk'
 ACCESS = 'access'
 BIND_IGNORE = 'bind_ignore'
@@ -23,7 +25,7 @@ BIND_SUCCESS = 'bind_success'
 BIND_FAILURE = 'bind_failure'
 HP_VIF_TYPE = 'hp-ironic'
 
-SUPPORTED_PROTOCOLS = ['snmpv1', 'snmpv2c', 'snmpv3']
+SUPPORTED_PROTOCOLS = ['snmpv1', 'snmpv2c', 'snmpv3', 'netconf-ssh', 'netconf-soap']
 SUPPORTED_AUTH_PROTOCOLS = [None, 'md5', 'sha', 'sha1']
 SUPPORTED_PRIV_PROTOCOLS = [None, 'des', '3des', 'aes',
                             'des56', 'aes128', 'aes192', 'aes256']
@@ -36,6 +38,9 @@ SNMP_V3 = 'snmpv3'
 SNMP_PORT = 161
 PHY_PORT_TYPE = '6'
 SNMP_NO_SUCH_INSTANCE = 'No Such'
+
+NETCONF_SSH = 'netconf-ssh'
+NETCONF_SOAP = 'netconf-soap'
 
 OID_MAC_ADDRESS = '1.0.8802.1.1.2.1.3.2.0'
 OID_IF_INDEX = '1.3.6.1.2.1.2.2.1.1'

--- a/baremetal_network_provisioning/common/validators.py
+++ b/baremetal_network_provisioning/common/validators.py
@@ -1,5 +1,5 @@
 # Copyright 2015 OpenStack Foundation
-# Copyright (c) 2015 Hewlett-Packard Development Company, L.P.
+# Copyright (c) 2016 Hewlett-Packard Development Company, L.P.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -14,6 +14,8 @@
 # under the License.
 # service type constants:
 
+from copy import deepcopy
+import os.path
 from simplejson import scanner as json_scanner
 import webob.exc
 
@@ -44,14 +46,18 @@ def validate_request(request):
         raise webob.exc.HTTPBadRequest(
             _("Invalid JSON body"))
     try:
-        body = body.pop(const.BNP_SWITCH_RESOURCE_NAME)
+        key = body.keys()
+        if key[0] in [const.BNP_SWITCH_RESOURCE_NAME,
+                   const.BNP_CREDENTIAL_RESOURCE_NAME]:
+            body = body.pop(key[0])
     except KeyError:
         raise webob.exc.HTTPBadRequest(
-            _("'bnp_switch' not found in request body"))
+            _("resource name not found in request body"))
     return body
 
 
 def validate_attributes(keys, attr_keys):
+    """Validate the keys in request body."""
     extra_keys = set(keys) - set(attr_keys)
     if extra_keys:
         msg = _("Unrecognized attribute(s) '%s'") % ', '.join(extra_keys)
@@ -59,27 +65,51 @@ def validate_attributes(keys, attr_keys):
 
 
 def validate_access_parameters(body):
-    if body['access_protocol'].lower() not in const.SUPPORTED_PROTOCOLS:
+    """Validate if the request body is in proper format."""
+    protocol_dict = deepcopy(body)
+    if const.NAME not in protocol_dict.keys():
         raise webob.exc.HTTPBadRequest(
-            _("'access protocol %s' is not supported") % body[
-                'access_protocol'])
-    access_parameters = body.get("access_parameters")
-    validate_attributes(access_parameters.keys(), access_parameter_keys)
-    if body['access_protocol'].lower() == const.SNMP_V3:
-        validate_snmpv3_parameters(access_parameters)
+                    _("Name not found in request body"))
+    protocol_dict.pop('name')
+    keys = protocol_dict.keys()
+    if not len(keys):
+        raise webob.exc.HTTPBadRequest(
+                    _("Request body should have at least one protocol specified"))
+    elif len(keys) > 1:
+        raise webob.exc.HTTPBadRequest(
+            _("multiple protocols in a single request is not supported"))
+    key = keys[0]
+    if key.lower() not in const.SUPPORTED_PROTOCOLS:
+        raise webob.exc.HTTPBadRequest(
+            _("'protocol %s' is not supported") % keys)
+    if key.lower() == const.SNMP_V3:
+        return validate_snmpv3_parameters(protocol_dict, key)
+    elif key.lower() in [const.NETCONF_SSH, const.NETCONF_SOAP]:
+        return validate_netconf_parameters(protocol_dict, key)
     else:
-        validate_snmp_parameters(access_parameters)
+        return validate_snmp_parameters(protocol_dict, key)
 
 
-def validate_snmp_parameters(access_parameters):
+def validate_snmp_parameters(protocol_dict, key):
     """Validate SNMP v1 and v2c parameters."""
+    access_parameters = protocol_dict.pop(key)
+    keys = access_parameters.keys()
+    validate_attributes(keys, ['write_community'])
     if not access_parameters.get('write_community'):
         raise webob.exc.HTTPBadRequest(
             _("'write_community' not found in request body"))
+    if key.lower() == const.SNMP_V1:
+        return const.SNMP_V1
+    else:
+        return const.SNMP_V2C
 
 
-def validate_snmpv3_parameters(access_parameters):
+def validate_snmpv3_parameters(protocol_dict, key):
     """Validate SNMP v3 parameters."""
+    access_parameters = protocol_dict.pop(key)
+    keys = access_parameters.keys()
+    attr_keys = ['security_name', 'auth_protocol', 'auth_key', 'priv_protocol', 'priv_key']
+    validate_attributes(keys, attr_keys)
     if not access_parameters.get('security_name'):
         raise webob.exc.HTTPBadRequest(
             _("security_name not found in request body"))
@@ -111,3 +141,36 @@ def validate_snmpv3_parameters(access_parameters):
             raise webob.exc.HTTPBadRequest(
                 _("'priv_key %s' should be equal or more than"
                   "8 characters") % access_parameters['priv_key'])
+    return const.SNMP_V3
+
+
+def _validate_user_name_password(access_parameters):
+    """Validate if the request contains user_name and password."""
+    if not access_parameters.get('user_name'):
+        raise webob.exc.HTTPBadRequest(
+            _("user_name not found in request body"))
+    elif not access_parameters.get('password'):
+        raise webob.exc.HTTPBadRequest(
+            _("password not found in request body"))
+
+
+def validate_netconf_parameters(protocol_dict, key):
+    """Validate NETCONF SSH/SOAP parameters"""
+    access_parameters = protocol_dict.pop(key)
+    if key.lower() == const.NETCONF_SSH:
+        if access_parameters.get('key_path'):
+            if not os.path.isfile(access_parameters.get('key_path')):
+                raise webob.exc.HTTPBadRequest(
+                    _("Invalid key path"))
+            if access_parameters.get('user_name') or access_parameters.get('password'):
+                raise webob.exc.HTTPBadRequest(
+                    _("Either specify username and password OR keypath, not both"))
+            return const.NETCONF_SSH
+        _validate_user_name_password(access_parameters)
+        return const.NETCONF_SSH
+    else:
+        if access_parameters.get('key_path'):
+            raise webob.exc.HTTPBadRequest(
+                    _("Invalid attribute key_path"))
+        _validate_user_name_password(access_parameters)
+        return const.NETCONF_SOAP

--- a/baremetal_network_provisioning/db/bm_nw_provision_db.py
+++ b/baremetal_network_provisioning/db/bm_nw_provision_db.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 OpenStack Foundation
+# Copyright (c) 2016 OpenStack Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -523,3 +523,82 @@ def get_bnp_phys_switch_ports_by_switch_id(context, switch_id):
         LOG.error('no ports found for physical switch %s', switch_id)
         return
     return switch_ports
+
+def add_bnp_snmp_cred(context, snmp_cred):
+    """Add SNMP Credential."""
+    session = context.session
+    with session.begin(subtransactions=True):
+        uuid = 's' + uuidutils.generate_uuid()
+        snmp_cred = models.BNPSNMPCredential(
+            id=uuid,
+            name=snmp_cred['name'],
+            proto_type=snmp_cred['proto_type'],
+            write_community=snmp_cred['write_community'],
+            security_name=snmp_cred['security_name'],
+            auth_protocol=snmp_cred['auth_protocol'],
+            auth_key=snmp_cred['auth_key'],
+            priv_protocol=snmp_cred['priv_protocol'],
+            priv_key=snmp_cred['priv_key'],
+            security_level=snmp_cred['security_level'])
+        session.add(snmp_cred)
+    return snmp_cred
+
+
+def add_bnp_netconf_cred(context, netconf_cred):
+    """Add NETCONF Credenial."""
+    session = context.session
+    with session.begin(subtransactions=True):
+        uuid = 'n' + uuidutils.generate_uuid()
+        netconf_cred = models.BNPNETCONFCredential(
+            id=uuid,
+            name=netconf_cred['name'],
+            proto_type=netconf_cred['proto_type'],
+            user_name=netconf_cred['user_name'],
+            password=netconf_cred['password'],
+            key_path=netconf_cred['key_path'])
+        session.add(netconf_cred)
+    return netconf_cred
+
+
+def get_snmp_cred_by_name(context, name):
+    """Get SNMP Credentail that matches name."""
+    try:
+        query = context.session.query(models.BNPSNMPCredential)
+        snmp_cred = query.filter_by(name=name).one()
+    except exc.NoResultFound:
+        LOG.info(_LI("no snmp credential found with name: %s"), name)
+        return
+    return snmp_cred
+
+
+def get_snmp_cred_by_id(context, id):
+    """Get SNMP Credentail that matches id."""
+    try:
+        query = context.session.query(models.BNPSNMPCredential)
+        snmp_cred = query.filter_by(id=id).one()
+    except exc.NoResultFound:
+        LOG.info(_LI("no snmp credential found with id: %s"), id)
+        return
+    return snmp_cred
+
+
+def get_netconf_cred_by_name(context, name):
+    """Get NETCONF Credentail that matches name."""
+    try:
+        query = context.session.query(models.BNPNETCONFCredential)
+        netconf_cred = query.filter_by(name=name).one()
+    except exc.NoResultFound:
+        LOG.info(_LI("no netconf credential found with name: %s"), name)
+        return
+    return netconf_cred
+
+
+def get_netconf_cred_by_id(context, id):
+    """Get NETCONF Credentail that matches id."""
+    try:
+        query = context.session.query(models.BNPNETCONFCredential)
+        netconf_cred = query.filter_by(id=id).one()
+    except exc.NoResultFound:
+        LOG.info(_LI("no netconf credential found with id: %s"), id)
+        return
+    return netconf_cred

--- a/baremetal_network_provisioning/db/bm_nw_provision_db.py
+++ b/baremetal_network_provisioning/db/bm_nw_provision_db.py
@@ -561,7 +561,7 @@ def add_bnp_netconf_cred(context, netconf_cred):
 
 
 def get_snmp_cred_by_name(context, name):
-    """Get SNMP Credentail that matches name."""
+    """Get SNMP Credential that matches name."""
     try:
         query = context.session.query(models.BNPSNMPCredential)
         snmp_cred = query.filter_by(name=name).one()
@@ -572,7 +572,7 @@ def get_snmp_cred_by_name(context, name):
 
 
 def get_snmp_cred_by_id(context, id):
-    """Get SNMP Credentail that matches id."""
+    """Get SNMP Credential that matches id."""
     try:
         query = context.session.query(models.BNPSNMPCredential)
         snmp_cred = query.filter_by(id=id).one()

--- a/baremetal_network_provisioning/db/bm_nw_provision_db.py
+++ b/baremetal_network_provisioning/db/bm_nw_provision_db.py
@@ -545,7 +545,7 @@ def add_bnp_snmp_cred(context, snmp_cred):
 
 
 def add_bnp_netconf_cred(context, netconf_cred):
-    """Add NETCONF Credenial."""
+    """Add NETCONF Credential."""
     session = context.session
     with session.begin(subtransactions=True):
         uuid = 'n' + uuidutils.generate_uuid()
@@ -583,7 +583,7 @@ def get_snmp_cred_by_id(context, id):
 
 
 def get_netconf_cred_by_name(context, name):
-    """Get NETCONF Credentail that matches name."""
+    """Get NETCONF Credential that matches name."""
     try:
         query = context.session.query(models.BNPNETCONFCredential)
         netconf_cred = query.filter_by(name=name).one()
@@ -594,7 +594,7 @@ def get_netconf_cred_by_name(context, name):
 
 
 def get_netconf_cred_by_id(context, id):
-    """Get NETCONF Credentail that matches id."""
+    """Get NETCONF Credential that matches id."""
     try:
         query = context.session.query(models.BNPNETCONFCredential)
         netconf_cred = query.filter_by(id=id).one()

--- a/baremetal_network_provisioning/ml2/extensions/bnp_credential.py
+++ b/baremetal_network_provisioning/ml2/extensions/bnp_credential.py
@@ -1,0 +1,204 @@
+# Copyright (c) 2016 Hewlett-Packard Development Company, L.P.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import webob.exc
+
+from neutron.api import extensions
+from neutron.api.v2 import attributes
+from neutron.api.v2 import base
+from neutron.api.v2 import resource
+from neutron.i18n import _LE
+from neutron import wsgi
+
+from baremetal_network_provisioning.common import constants as const
+from baremetal_network_provisioning.common import validators
+from baremetal_network_provisioning.db import bm_nw_provision_db as db
+from baremetal_network_provisioning.drivers import discovery_driver
+
+from oslo_log import log as logging
+
+LOG = logging.getLogger(__name__)
+
+
+RESOURCE_ATTRIBUTE_MAP = {
+    'bnp-credentials': {
+        'id': {'allow_post': False, 'allow_put': False,
+               'is_visible': True},
+        'name': {'allow_post': True, 'allow_put': True,
+                 'validate': {'type:string': None},
+                 'is_visible': True},
+        'snmpv1': {'allow_post': True, 'allow_put': True,
+                   'validate': {'type:access_dict': None},
+                   'is_visible': True},
+        'snmpv2c': {'allow_post': True, 'allow_put': True,
+                    'validate': {'type:access_dict': None},
+                    'is_visible': True},
+        'snmpv3': {'allow_post': True, 'allow_put': True,
+                   'validate': {'type:access_dict': None},
+                   'is_visible': True},
+        'netconf-ssh': {'allow_post': True, 'allow_put': True,
+                        'validate': {'type:access_dict': None},
+                        'is_visible': True},
+        'netconf-soap': {'allow_post': True, 'allow_put': True,
+                         'validate': {'type:access_dict': None},
+                         'is_visible': True},
+    },
+}
+
+validator_func = validators.access_parameter_validator
+attributes.validators['type:access_dict'] = validator_func
+
+
+class BNPCredentialController(wsgi.Controller):
+
+    """WSGI Controller for the extension bnp-credential."""
+
+    def _check_admin(self, context):
+        reason = _("Only admin can configure Bnp-credential")
+        if not context.is_admin:
+            raise webob.exc.HTTPForbidden(reason)
+
+    def index(self, request, **kwargs):
+        pass
+
+    def show(self, request, id, **kwargs):
+        pass
+
+    def delete(self, request, id, **kwargs):
+        pass
+
+    def create(self, request, **kwargs):
+        """Create a new Credential"""
+        context = request.context
+        self._check_admin(context)
+        body = validators.validate_request(request)
+        key_list = ['name', 'snmpv1', 'snmpv2c',
+                    'snmpv3', 'netconf-ssh', 'netconf-soap']
+        keys = body.keys()
+        validators.validate_attributes(keys, key_list)
+        protocol = validators.validate_access_parameters(body)
+        if protocol in ['snmpv1', 'snmpv2c', 'snmpv3']:
+            db_snmp_cred = self._create_snmp_creds(context, body, protocol)
+            return {const.BNP_CREDENTIAL_RESOURCE_NAME: dict(db_snmp_cred)}
+        else:
+            db_netconf_cred = self._create_netconf_creds(context, body, protocol)
+            return {const.BNP_CREDENTIAL_RESOURCE_NAME: dict(db_netconf_cred)}
+
+    def _create_snmp_creds(self, context, body, protocol):
+        """Create a new SNMP Credential"""
+        name = body.get('name')
+        snmp_cred = db.get_snmp_cred_by_name(context,
+                                             name)
+        if snmp_cred:
+            raise webob.exc.HTTPConflict(
+                _("SNMP Credential with %s name already present") %
+                name)
+        access_parameters = body.pop(protocol)
+        snmp_cred_dict = self._create_snmp_cred_dict()
+        for key, value in access_parameters.iteritems():
+            body[key] = value
+        body['proto_type'] = protocol
+        snmp_cred = self._update_dict(body, snmp_cred_dict)
+        db_snmp_cred = db.add_bnp_snmp_cred(context, snmp_cred)
+        return db_snmp_cred
+
+    def _create_netconf_creds(self, context, body, protocol):
+        """Create a new NETCONF Credential"""
+        name = body.get('name')
+        netconf_cred = db.get_netconf_cred_by_name(context,
+                                                   name)
+        if netconf_cred:
+            raise webob.exc.HTTPConflict(
+                _("NETCONF Credential with %s name already present") %
+                name)
+        access_parameters = body.pop(protocol)
+        netconf_cred_dict = self._create_netconf_cred_dict()
+        for key, value in access_parameters.iteritems():
+            body[key] = value
+        body['proto_type'] = protocol
+        netconf_cred = self._update_dict(body, netconf_cred_dict)
+        db_netconf_cred = db.add_bnp_netconf_cred(context, netconf_cred)
+        return db_netconf_cred
+
+
+    def _create_snmp_cred_dict(self):
+        """Create SNMP credential dict"""
+        snmp_cred_dict = {
+            'name': None,
+            'proto_type': None,
+            'security_name': None,
+            'write_community': None,
+            'auth_protocol': None,
+            'auth_key': None,
+            'priv_protocol': None,
+            'priv_key': None,
+            'security_level': None}
+        return snmp_cred_dict
+
+    def _create_netconf_cred_dict(self):
+        """Create NETCONF credential dict"""
+        netconf_cred_dict = {
+            'name': None,
+            'proto_type': None,
+            'user_name': None,
+            'password': None,
+            'key_path': None}
+        return netconf_cred_dict
+
+    def _update_dict(self, body, cred_dict):
+        """Update the existing dict""" 
+        for key in cred_dict.keys():
+            if key in body.keys():
+                cred_dict[key] = body[key]
+        return cred_dict
+
+    def update(self, request, id, **kwargs):
+        pass
+
+
+class Bnp_credential(extensions.ExtensionDescriptor):
+
+    """API extension for Baremetal Switch Credential support."""
+
+    @classmethod
+    def get_name(cls):
+        return "Bnp-Credential"
+
+    @classmethod
+    def get_alias(cls):
+        return "bnp-credential"
+
+    @classmethod
+    def get_description(cls):
+        return ("Abstraction for protocol credentials"
+                " for bare metal instance network provisioning")
+
+    @classmethod
+    def get_updated(cls):
+        return "2016-03-22T00:00:00-00:00"
+
+    def get_resources(self):
+        exts = []
+        controller = resource.Resource(BNPCredentialController(),
+                                       base.FAULT_MAP)
+        exts.append(extensions.ResourceExtension(
+            'bnp-credentials', controller))
+        return exts
+
+    def get_extended_resources(self, version):
+        if version == "2.0":
+            return RESOURCE_ATTRIBUTE_MAP
+        else:
+            return {}

--- a/baremetal_network_provisioning/ml2/hpe_ironic_credential_ext_driver.py
+++ b/baremetal_network_provisioning/ml2/hpe_ironic_credential_ext_driver.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2016 OpenStack Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from neutron.api import extensions as neutron_extensions
+from neutron.plugins.ml2 import driver_api as api
+
+from baremetal_network_provisioning.ml2 import extensions
+
+from oslo_log import log as logging
+
+LOG = logging.getLogger(__name__)
+
+
+class HPEIronicCredentialExtDriver(api.ExtensionDriver):
+    _supported_extension_aliases = "bnp-credential"
+
+    def initialize(self):
+        neutron_extensions.append_api_extensions_path(extensions.__path__)
+        LOG.info(_("HPEIronicCredentialExtDriver initialization complete"))
+
+    @property
+    def extension_alias(self):
+        """Supported extension alias.
+
+        identifying the core API extension supported
+                  by this BNP driver
+        """
+        return self._supported_extension_aliases[:]

--- a/devstack/README.rst
+++ b/devstack/README.rst
@@ -18,7 +18,7 @@ Enabling Baremetal Network Provisioning in Devstack
 4. Add the following required flag in local.conf to enable BNP Extension driver::
     
     #append the below lines
-    Q_ML2_PLUGIN_EXT_DRIVERS=port_security,bnp_ext_driver
+    Q_ML2_PLUGIN_EXT_DRIVERS=port_security,bnp_ext_driver,bnp_cred_ext_driver
   
 5. Provide the extra config file in local.conf for loading mechanism driver::
 

--- a/devstack/plugin.sh
+++ b/devstack/plugin.sh
@@ -31,6 +31,7 @@ function configure_bnp_plugin {
     iniadd $BNP_ML2_CONF_HPE_FILE ml2_hpe net_provisioning_driver $NET_PROVISIONING_DRIVER
     iniset $BNP_ENTRY_POINT_FILE neutron.ml2.mechanism_drivers hpe_bnp $HPE_MECHANISM_DRIVER
     iniset $BNP_ENTRY_POINT_FILE neutron.ml2.extension_drivers bnp_ext_driver $BNP_EXTENSION_DRIVER
+    iniset $BNP_ENTRY_POINT_FILE neutron.ml2.extension_drivers bnp_cred_ext_driver $BNP_CRED_EXT_DRIVER
 }
 
 

--- a/devstack/settings
+++ b/devstack/settings
@@ -6,6 +6,7 @@ NEUTRON_CONF_DIR=/etc/neutron/plugins/ml2
 NET_PROVISIONING_DRIVER=baremetal_network_provisioning.drivers.hp.hp_snmp_provisioning_driver.HPSNMPProvisioningDriver
 HPE_MECHANISM_DRIVER=baremetal_network_provisioning.ml2.mechanism_hpe:HPEMechanismDriver
 BNP_EXTENSION_DRIVER=baremetal_network_provisioning.ml2.hpeironicextensiondriver:HPEIronicExtensionDriver
+BNP_CRED_EXT_DRIVER=baremetal_network_provisioning.ml2.hpe_ironic_credential_ext_driver:HPEIronicCredentialExtDriver
 #
 # Each service you enable has the following meaning:
 # bnp-plugin - Add this config flag to  enable bnp service plugin

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ neutron.db.alembic_migrations =
     baremetal-network-provisioning = baremetal_network_provisioning.db.migration:alembic_migrations
 neutron.ml2.extension_drivers =
     bnp_ext_driver = baremetal_network_provisioning.ml2.hpeironicextensiondriver:HPEIronicExtensionDriver
+    bnp_cred_ext_driver = baremetal_network_provisioning.ml2.hpe_ironic_credential_ext_driver:HPEIronicCredentialExtDriver
 bnpclient.extension =
     bnp_switch = baremetal_network_provisioning.bnpclient.bnp_client_ext.bnpswitch._bnp_switch
 


### PR DESCRIPTION
Validators.py
L 55: It is common method for switch and credential, so we cant mention the exact resource name.
L.68 :Done
L:82: This is already taken care
For SOAP-- it is taken care
 Doc strings handled for all methods.

Even if the netconf-soap doesnt require, if the user specifies key_path it  then we need to inform him that it is wrong attribute.

Copyrights changed for respective files.

bnp_credential.py
L 69: Done
L 157: Done
In def _create_snmp_creds and _create_netconf_creds
   return statement included

hpe_ironic_credential_ext_driver.py
L40: Done

