### PR TITLE
Credential REST API's for DELETE/LIST/SHOW

### DIFF
--- a/baremetal_network_provisioning/common/constants.py
+++ b/baremetal_network_provisioning/common/constants.py
@@ -26,7 +26,7 @@ BIND_FAILURE = 'bind_failure'
 HP_VIF_TYPE = 'hp-ironic'
 
 SUPPORTED_PROTOCOLS = ['snmpv1', 'snmpv2c',
-                       'snmpv3', 'netconf-ssh', 'netconf-soap']
+                       'snmpv3', 'netconf_ssh', 'netconf_soap']
 SUPPORTED_AUTH_PROTOCOLS = [None, 'md5', 'sha', 'sha1']
 SUPPORTED_PRIV_PROTOCOLS = [None, 'des', '3des', 'aes',
                             'des56', 'aes128', 'aes192', 'aes256']
@@ -40,8 +40,8 @@ SNMP_PORT = 161
 PHY_PORT_TYPE = '6'
 SNMP_NO_SUCH_INSTANCE = 'No Such'
 
-NETCONF_SSH = 'netconf-ssh'
-NETCONF_SOAP = 'netconf-soap'
+NETCONF_SSH = 'netconf_ssh'
+NETCONF_SOAP = 'netconf_soap'
 
 OID_MAC_ADDRESS = '1.0.8802.1.1.2.1.3.2.0'
 OID_IF_INDEX = '1.3.6.1.2.1.2.2.1.1'

--- a/baremetal_network_provisioning/common/validators.py
+++ b/baremetal_network_provisioning/common/validators.py
@@ -22,6 +22,8 @@ import os.path
 
 from baremetal_network_provisioning.common import constants as const
 
+from oslo_utils import uuidutils
+
 
 access_parameter_keys = ['write_community', 'security_name',
                          'auth_protocol', 'priv_protocol', 'auth_key',
@@ -83,6 +85,10 @@ def validate_access_parameters(body):
     if const.NAME not in protocol_dict.keys():
         raise webob.exc.HTTPBadRequest(
             _("Name not found in request body"))
+    if uuidutils.is_uuid_like(protocol_dict['name']):
+        raise webob.exc.HTTPBadRequest(
+            _("Name=%s should not be in uuid format") %
+            protocol_dict['name'])
     protocol_dict.pop('name')
     keys = protocol_dict.keys()
     if not len(keys):
@@ -176,10 +182,6 @@ def validate_netconf_parameters(protocol_dict, key):
             if not os.path.isfile(access_parameters.get('key_path')):
                 raise webob.exc.HTTPBadRequest(
                     _("Invalid key path"))
-            if (access_parameters.get('user_name') or
-               access_parameters.get('password')):
-                raise webob.exc.HTTPBadRequest(
-                    _("Specify username and password OR keypath, not both"))
             return const.NETCONF_SSH
         _validate_user_name_password(access_parameters)
         return const.NETCONF_SSH

--- a/baremetal_network_provisioning/db/bm_nw_provision_db.py
+++ b/baremetal_network_provisioning/db/bm_nw_provision_db.py
@@ -527,7 +527,7 @@ def add_bnp_snmp_cred(context, snmp_cred):
     """Add SNMP Credential."""
     session = context.session
     with session.begin(subtransactions=True):
-        uuid = 's' + uuidutils.generate_uuid()
+        uuid = uuidutils.generate_uuid()
         snmp_cred = models.BNPSNMPCredential(
             id=uuid,
             name=snmp_cred['name'],
@@ -547,7 +547,7 @@ def add_bnp_netconf_cred(context, netconf_cred):
     """Add NETCONF Credential."""
     session = context.session
     with session.begin(subtransactions=True):
-        uuid = 'n' + uuidutils.generate_uuid()
+        uuid = uuidutils.generate_uuid()
         netconf_cred = models.BNPNETCONFCredential(
             id=uuid,
             name=netconf_cred['name'],
@@ -559,15 +559,39 @@ def add_bnp_netconf_cred(context, netconf_cred):
     return netconf_cred
 
 
+def get_all_snmp_creds(context, **args):
+    """Get all physical switches."""
+    try:
+        query = context.session.query(
+            models.BNPSNMPCredential).filter_by(**args)
+        snmp_creds = query.all()
+    except exc.NoResultFound:
+        LOG.error(_LE("no snmp credential found"))
+        return
+    return snmp_creds
+
+
+def get_all_netconf_creds(context, **args):
+    """Get all physical switches."""
+    try:
+        query = context.session.query(
+            models.BNPNETCONFCredential).filter_by(**args)
+        netconf_creds = query.all()
+    except exc.NoResultFound:
+        LOG.error(_LE("no netconf credential found"))
+        return
+    return netconf_creds
+
+
 def get_snmp_cred_by_name(context, name):
     """Get SNMP Credential that matches name."""
     try:
         query = context.session.query(models.BNPSNMPCredential)
-        snmp_cred = query.filter_by(name=name).one()
+        snmp_creds = query.filter_by(name=name).all()
     except exc.NoResultFound:
         LOG.info(_LI("no snmp credential found with name: %s"), name)
         return
-    return snmp_cred
+    return snmp_creds
 
 
 def get_snmp_cred_by_id(context, id):
@@ -585,11 +609,11 @@ def get_netconf_cred_by_name(context, name):
     """Get NETCONF Credential that matches name."""
     try:
         query = context.session.query(models.BNPNETCONFCredential)
-        netconf_cred = query.filter_by(name=name).one()
+        netconf_creds = query.filter_by(name=name).all()
     except exc.NoResultFound:
         LOG.info(_LI("no netconf credential found with name: %s"), name)
         return
-    return netconf_cred
+    return netconf_creds
 
 
 def get_netconf_cred_by_id(context, id):
@@ -601,6 +625,22 @@ def get_netconf_cred_by_id(context, id):
         LOG.info(_LI("no netconf credential found with id: %s"), id)
         return
     return netconf_cred
+
+
+def delete_snmp_cred_by_id(context, id):
+    """Delete snmp credential by id."""
+    session = context.session
+    with session.begin(subtransactions=True):
+        session.query(models.BNPSNMPCredential).filter_by(
+            id=id).delete()
+
+
+def delete_netconf_cred_by_id(context, id):
+    """Delete snmp credential by id."""
+    session = context.session
+    with session.begin(subtransactions=True):
+        session.query(models.BNPNETCONFCredential).filter_by(
+            id=id).delete()
 
 
 def get_bnp_phys_switch_by_name(context, name):

--- a/baremetal_network_provisioning/db/bm_nw_provision_db.py
+++ b/baremetal_network_provisioning/db/bm_nw_provision_db.py
@@ -628,7 +628,7 @@ def get_netconf_cred_by_id(context, id):
 
 
 def delete_snmp_cred_by_id(context, id):
-    """Delete snmp credential by id."""
+    """Delete SNMP credential by id."""
     session = context.session
     with session.begin(subtransactions=True):
         session.query(models.BNPSNMPCredential).filter_by(
@@ -636,7 +636,7 @@ def delete_snmp_cred_by_id(context, id):
 
 
 def delete_netconf_cred_by_id(context, id):
-    """Delete snmp credential by id."""
+    """Delete NETCONF credential by id."""
     session = context.session
     with session.begin(subtransactions=True):
         session.query(models.BNPNETCONFCredential).filter_by(

--- a/baremetal_network_provisioning/db/bm_nw_provision_db.py
+++ b/baremetal_network_provisioning/db/bm_nw_provision_db.py
@@ -560,7 +560,7 @@ def add_bnp_netconf_cred(context, netconf_cred):
 
 
 def get_all_snmp_creds(context, **args):
-    """Get all physical switches."""
+    """Get all SNMP Credentials."""
     try:
         query = context.session.query(
             models.BNPSNMPCredential).filter_by(**args)
@@ -572,7 +572,7 @@ def get_all_snmp_creds(context, **args):
 
 
 def get_all_netconf_creds(context, **args):
-    """Get all physical switches."""
+    """Get all NETCONF Credentials."""
     try:
         query = context.session.query(
             models.BNPNETCONFCredential).filter_by(**args)

--- a/baremetal_network_provisioning/db/bm_nw_provision_models.py
+++ b/baremetal_network_provisioning/db/bm_nw_provision_models.py
@@ -120,8 +120,7 @@ class BNPSNMPCredential(model_base.BASEV2, models_v2.HasId):
     priv_protocol = sa.Column(sa.String(16), nullable=True)
     priv_key = sa.Column(sa.String(255), nullable=True)
     security_level = sa.Column(sa.String(16), nullable=True)
-    __table_args__ = (sa.PrimaryKeyConstraint('id'),
-                      sa.UniqueConstraint('name'),)
+    __table_args__ = (sa.PrimaryKeyConstraint('id'),)
 
 
 class BNPNETCONFCredential(model_base.BASEV2, models_v2.HasId):
@@ -132,5 +131,4 @@ class BNPNETCONFCredential(model_base.BASEV2, models_v2.HasId):
     user_name = sa.Column(sa.String(255), nullable=True)
     password = sa.Column(sa.String(255), nullable=True)
     key_path = sa.Column(sa.String(255), nullable=True)
-    __table_args__ = (sa.PrimaryKeyConstraint('id'),
-                      sa.UniqueConstraint('name'),)
+    __table_args__ = (sa.PrimaryKeyConstraint('id'),)

--- a/baremetal_network_provisioning/db/migration/alembic_migrations/versions/3297cd3f2323_bm_nw_provision_models.py
+++ b/baremetal_network_provisioning/db/migration/alembic_migrations/versions/3297cd3f2323_bm_nw_provision_models.py
@@ -80,7 +80,7 @@ def upgrade():
                     sa.UniqueConstraint('ip_address'))
 
     op.create_table('bnp_snmp_credentials',
-                    sa.Column('id', sa.String(40), nullable=False),
+                    sa.Column('id', sa.String(36), nullable=False),
                     sa.Column('name', sa.String(36), nullable=False),
                     sa.Column('proto_type', sa.String(255), nullable=False),
                     sa.Column('write_community',
@@ -91,18 +91,16 @@ def upgrade():
                     sa.Column('priv_protocol', sa.String(16), nullable=True),
                     sa.Column('priv_key', sa.String(255), nullable=True),
                     sa.Column('security_level', sa.String(16), nullable=True),
-                    sa.PrimaryKeyConstraint('id'),
-                    sa.UniqueConstraint('name'))
+                    sa.PrimaryKeyConstraint('id'))
 
     op.create_table('bnp_netconf_credentials',
-                    sa.Column('id', sa.String(40), nullable=False),
+                    sa.Column('id', sa.String(36), nullable=False),
                     sa.Column('name', sa.String(36), nullable=False),
                     sa.Column('proto_type', sa.String(255), nullable=False),
                     sa.Column('user_name', sa.String(255), nullable=True),
                     sa.Column('password', sa.String(255), nullable=True),
                     sa.Column('key_path', sa.String(255), nullable=True),
-                    sa.PrimaryKeyConstraint('id'),
-                    sa.UniqueConstraint('name'))
+                    sa.PrimaryKeyConstraint('id'))
 
     op.create_table('bnp_physical_switch_ports',
                     sa.Column('id', sa.String(36), nullable=False),

--- a/baremetal_network_provisioning/ml2/extensions/bnp_credential.py
+++ b/baremetal_network_provisioning/ml2/extensions/bnp_credential.py
@@ -69,13 +69,19 @@ class BNPCredentialController(wsgi.Controller):
             raise webob.exc.HTTPForbidden(reason)
 
     def index(self, request, **kwargs):
-        pass
-
-    def show(self, request, id, **kwargs):
-        pass
-
-    def delete(self, request, id, **kwargs):
-        pass
+        context = request.context
+        filters = {}
+        creds = []
+        req_dict = dict(request.GET)
+        if req_dict:
+            filters = req_dict
+        creds = db.get_all_snmp_creds(context, **filters)
+        netconf_creds = db.get_all_netconf_creds(context, **filters)
+        for i in netconf_creds:
+            creds.append(i)
+        creds = self._creds_to_show(creds)
+        creds_dict = {'bnp_credentials': creds}
+        return creds_dict
 
     def _creds_to_show(self, creds):
         attr_list = ['security_name', 'auth_protocol', 'auth_key',
@@ -97,13 +103,39 @@ class BNPCredentialController(wsgi.Controller):
                     cred.pop(key)
             return cred
 
+    def show(self, request, id, **kwargs):
+        context = request.context
+        snmp_cred = db.get_snmp_cred_by_id(context, id)
+        netconf_cred = db.get_netconf_cred_by_id(context, id)
+        if snmp_cred:
+            cred = self._creds_to_show(snmp_cred)
+        elif netconf_cred:
+            cred = self._creds_to_show(netconf_cred)
+        else:
+            raise webob.exc.HTTPNotFound(
+                _("Credential with id=%s does not exist") % id)
+        return {const.BNP_CREDENTIAL_RESOURCE_NAME: cred}
+
+    def delete(self, request, id, **kwargs):
+        context = request.context
+        self._check_admin(context)
+        snmp_cred = db.get_snmp_cred_by_id(context, id)
+        netconf_cred = db.get_netconf_cred_by_id(context, id)
+        if snmp_cred:
+            db.delete_snmp_cred_by_id(context, id)
+        elif netconf_cred:
+            db.delete_netconf_cred_by_id(context, id)
+        else:
+            raise webob.exc.HTTPNotFound(
+                _("Credential with id=%s does not exist") % id)
+
     def create(self, request, **kwargs):
         """Create a new Credential."""
         context = request.context
         self._check_admin(context)
         body = validators.validate_request(request)
         key_list = ['name', 'snmpv1', 'snmpv2c',
-                    'snmpv3', 'netconf-ssh', 'netconf-soap']
+                    'snmpv3', 'netconf_ssh', 'netconf_soap']
         keys = body.keys()
         validators.validate_attributes(keys, key_list)
         protocol = validators.validate_access_parameters(body)
@@ -119,13 +151,6 @@ class BNPCredentialController(wsgi.Controller):
 
     def _create_snmp_creds(self, context, body, protocol):
         """Create a new SNMP Credential."""
-        name = body.get('name')
-        snmp_cred = db.get_snmp_cred_by_name(context,
-                                             name)
-        if snmp_cred:
-            raise webob.exc.HTTPConflict(
-                _("SNMP Credential with %s name already present") %
-                name)
         access_parameters = body.pop(protocol)
         snmp_cred_dict = self._create_snmp_cred_dict()
         for key, value in access_parameters.iteritems():
@@ -137,13 +162,6 @@ class BNPCredentialController(wsgi.Controller):
 
     def _create_netconf_creds(self, context, body, protocol):
         """Create a new NETCONF Credential."""
-        name = body.get('name')
-        netconf_cred = db.get_netconf_cred_by_name(context,
-                                                   name)
-        if netconf_cred:
-            raise webob.exc.HTTPConflict(
-                _("NETCONF Credential with %s name already present") %
-                name)
         access_parameters = body.pop(protocol)
         netconf_cred_dict = self._create_netconf_cred_dict()
         for key, value in access_parameters.iteritems():

--- a/baremetal_network_provisioning/ml2/extensions/bnp_credential.py
+++ b/baremetal_network_provisioning/ml2/extensions/bnp_credential.py
@@ -46,10 +46,10 @@ RESOURCE_ATTRIBUTE_MAP = {
         'snmpv3': {'allow_post': True, 'allow_put': True,
                    'validate': {'type:access_dict': None},
                    'is_visible': True},
-        'netconf-ssh': {'allow_post': True, 'allow_put': True,
+        'netconf_ssh': {'allow_post': True, 'allow_put': True,
                         'validate': {'type:access_dict': None},
                         'is_visible': True},
-        'netconf-soap': {'allow_post': True, 'allow_put': True,
+        'netconf_soap': {'allow_post': True, 'allow_put': True,
                          'validate': {'type:access_dict': None},
                          'is_visible': True},
     },
@@ -73,8 +73,9 @@ class BNPCredentialController(wsgi.Controller):
         filters = {}
         creds = []
         req_dict = dict(request.GET)
-        if req_dict:
-            filters = req_dict
+        if req_dict and req_dict.get('fields', None):
+            req_dict.pop('fields')
+        filters = req_dict
         creds = db.get_all_snmp_creds(context, **filters)
         netconf_creds = db.get_all_netconf_creds(context, **filters)
         for i in netconf_creds:


### PR DESCRIPTION
1. added support for Credential REST API's for DELETE/LIST/SHOW commands
2. multiple names are allowed
3. keypath issue addressed in netconf
4. appending 's' or  'n' to uuid in credential create is removed.
5. changded db schema for uuid back to 36 characters.